### PR TITLE
Add arm support

### DIFF
--- a/.github/workflows/publish_amd64.yml
+++ b/.github/workflows/publish_amd64.yml
@@ -1,0 +1,51 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            seasketch/geoprocessing-workspace
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=sha
+      -
+        name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          file: Dockerfile
+          context: .
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          push: true
+          tags: |
+            seasketch/geoprocessing-workspace:latest
+            ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish_amd64.yml
+++ b/.github/workflows/publish_amd64.yml
@@ -39,7 +39,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
-          file: Dockerfile
+          file: DockerfileAmd64
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish_arm64.yml
+++ b/.github/workflows/publish_arm64.yml
@@ -39,10 +39,11 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v3
         with:
+          file: DockerfileArm64
           context: .
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/arm64
           push: true
           tags: |
             seasketch/geoprocessing-workspace:latest

--- a/DockerfileAmd64
+++ b/DockerfileAmd64
@@ -1,0 +1,39 @@
+#----------------------------------- #
+# Use for Intel or AMd processorts
+# github: seasketch/docker-gp-workspace
+# docker: seasketch/geoprocessing-workspace
+#----------------------------------- #
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/devcontainers/base:${VARIANT} as builder
+
+RUN apt-get update && apt-get -y upgrade \
+  && apt-get install -y --no-install-recommends \
+    postgresql-client \
+    openjdk-17-jdk \
+    git \
+    wget \
+    g++ \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+ENV PATH="/root/miniconda3/bin:${PATH}"
+ARG PATH="/root/miniconda3/bin:${PATH}"
+RUN touch /root/.bashrc
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && mkdir /root/.conda \
+    && bash Miniconda3-latest-Linux-x86_64.sh -b \
+    && rm -f Miniconda3-latest-Linux-x86_64.sh \
+    && echo "Running $(conda --version)" && \
+    conda init bash && \
+    . /root/.bashrc && \
+    conda update conda && \
+    conda install python=3.8 pip && \
+    conda install -c conda-forge gdal=3.3.1
+
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION v16.16.0
+ENV NPM_VERSION 8.11.0
+RUN mkdir -p /usr/local/nvm && apt-get update && echo "y" | apt-get install curl
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
+RUN /bin/bash -c "source $NVM_DIR/nvm.sh && nvm install $NODE_VERSION && nvm use --delete-prefix $NODE_VERSION && npm install -g npm@$NPM_VERSION"
+ENV NODE_PATH $NVM_DIR/versions/node/$NODE_VERSION/bin
+ENV PATH $NODE_PATH:$PATH

--- a/DockerfileArm64
+++ b/DockerfileArm64
@@ -1,4 +1,5 @@
 #----------------------------------- #
+# Use for arm / apple silicon processors
 # github: seasketch/docker-gp-workspace
 # docker: seasketch/geoprocessing-workspace
 #----------------------------------- #
@@ -17,10 +18,10 @@ RUN apt-get update && apt-get -y upgrade \
 ENV PATH="/root/miniconda3/bin:${PATH}"
 ARG PATH="/root/miniconda3/bin:${PATH}"
 RUN touch /root/.bashrc
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh \
     && mkdir /root/.conda \
-    && bash Miniconda3-latest-Linux-x86_64.sh -b \
-    && rm -f Miniconda3-latest-Linux-x86_64.sh \
+    && bash Miniconda3-latest-Linux-aarch64.sh -b \
+    && rm -f Miniconda3-latest-Linux-aarch64.sh \
     && echo "Running $(conda --version)" && \
     conda init bash && \
     . /root/.bashrc && \

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ buildamd64:
 	docker build --tag seasketch/geoprocessing-workspace:$(TAG) --file DockerfileAmd64 .
 	docker tag seasketch/geoprocessing-workspace:$(TAG) seasketch/geoprocessing-workspace:latest
 
-# build multi-arch for both amd and arm processors.  Currently not working properly
 buildarm64:
 	docker buildx build --platform linux/arm64 -t seasketch/geoprocessing-workspace -f DockerfileArm64 .
 


### PR DESCRIPTION
This is functional but the build could probably be accomplished with a single dockerfile using conditional logic on the BUILDTARGET for deciding which conda build to install, then a single buildx multi-arch command `arm64, amd64`